### PR TITLE
Fix import typo in readme sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ you can also do the following:
 // in app/routes/application.js
 
 import Ember from 'ember';
-import TransitionToListenerMixin from '../mixins/transition-to-listener';
+import TransitionToListenerMixin from 'ember-cli-routing-service/mixins/transition-to-listener';
 
 export default Ember.Route.extend(TransitionToListenerMixin, {
   init: function() {


### PR DESCRIPTION
Was hitting the following error after copy/pasting sample code

```
Uncaught Error: Could not find module `myapp/mixins/transition-to-listener` imported from `myapp/routes/main-app`
```

Turns out replacing the `..` with the addon name solves it.
